### PR TITLE
add config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: go
 sudo: false
 go:
-- 1.8.x
+- 1.12.x
 before_install:
 - go get -u github.com/z4yx/GoAuthing/cli
 install:
-- 
+-
 script:
 - GOARCH=amd64 GOOS=linux go build -o auth-thu.linux.amd64 github.com/z4yx/GoAuthing/cli
 - GOARCH=amd64 GOOS=darwin go build -o auth-thu.macos github.com/z4yx/GoAuthing/cli

--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ GLOBAL OPTIONS:
    --version, -v                     print the version
 ```
 
+Write a config file to store your username & password in the following format.
+The default location of config file is `~/.auth-thu`.
+
+```
+{
+  "username": your-username,
+  "password": your-password
+}
+```
+
 ## Build
 
 ```
@@ -53,5 +63,3 @@ This project was inspired by the following projects:
 
 - https://github.com/jiegec/auth-tsinghua
 - https://github.com/Berrysoft/ClassLibrary
-
-


### PR DESCRIPTION
Read username & password from a config file, so that you do not need to enter it every time, and do not to put it in the command line.