### PR TITLE
Add persistent option in config file for campus-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ USAGE:
    auth-thu [options] online [online_options]
 
 VERSION:
-   2.0.0
+   2.0.1
 
 AUTHORS:
    Yuxiang Zhang <yuxiang.zhang@tuna.tsinghua.edu.cn>

--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ The default location of config file is `~/.auth-thu`.
   "noCheck": false,
   "insecure": false,
   "daemonize": false,
-  "acId": ""
+  "acId": "",
+  "campusOnly": false
 }
 ```
 

--- a/cli/main.go
+++ b/cli/main.go
@@ -35,6 +35,7 @@ type Settings struct {
 	Daemon   bool   `json:"daemonize"`
 	Debug    bool   `json:"debug"`
 	AcID     string `json:"acId"`
+	Campus   bool   `json:"campusOnly"`
 }
 
 var logger = loggo.GetLogger("auth-thu")
@@ -91,6 +92,7 @@ func mergeCliSettings(c *cli.Context) error {
 	if len(merged.AcID) == 0 {
 		merged.AcID = settings.AcID
 	}
+	merged.Campus = settings.Campus || c.Bool("campus-only")
 	settings = merged
 	logger.Debugf("Settings Username: \"%s\"\n", settings.Username)
 	logger.Debugf("Settings Ip: \"%s\"\n", settings.Ip)
@@ -103,6 +105,7 @@ func mergeCliSettings(c *cli.Context) error {
 	logger.Debugf("Settings Daemon: %t\n", settings.Daemon)
 	logger.Debugf("Settings Debug: %t\n", settings.Debug)
 	logger.Debugf("Settings AcID: \"%s\"\n", settings.AcID)
+	logger.Debugf("Settings Campus: %t\n", settings.Campus)
 	return nil
 }
 
@@ -312,7 +315,7 @@ func cmdAuthUtil(c *cli.Context, logout bool) error {
 		}
 	}
 
-	if c.Bool("campus-only") {
+	if settings.Campus {
 		settings.Username += "@tsinghua"
 	}
 

--- a/cli/main.go
+++ b/cli/main.go
@@ -409,7 +409,7 @@ func main() {
 	 auth-thu [options] logout
 	 auth-thu [options] online [online_options]`,
 		Usage:    "Authenticating utility for Tsinghua",
-		Version:  "2.0.0",
+		Version:  "2.0.1",
 		HideHelp: true,
 		Flags: []cli.Flag{
 			&cli.StringFlag{Name: "username, u", Usage: "your TUNET account `name`"},


### PR DESCRIPTION
As in v1.9.7, `campus-only` is added but not added in config file.
This is a minor fix.