### PR TITLE
Add autostart script for OpenWRT

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/z4yx/GoAuthing.svg?branch=master)](https://travis-ci.org/z4yx/GoAuthing)
 ![GPLv3](https://img.shields.io/badge/license-GPLv3-blue.svg)
 
-A commandline Tunet (auth4/6.tsinghua.edu.cn, Tsinghua-IPv4) authentication tool.
+A command-line Tunet (auth4/6.tsinghua.edu.cn, Tsinghua-IPv4) authentication tool.
 
 ## Download Binary
 
@@ -96,15 +96,28 @@ Write a config file to store your username & password or other options in the fo
 
 Unless you have special need, you can only have `username` and `password` field in your config file. For `host`, the default value defined in code should be sufficient hence there should be no need to fill it. `UseV6` automatically determine the `host` to use. For `ip`, unless you are auth/login the other boxes you have(not the box `auth-thu` is running on), you can leave it blank. For those boxes unable to get correct acid themselves, we can specify the acid for them by using `acId`. Other options are self-explanatory.
 
-To configure automatic authentication on systemd based Linux distro, take a look at `docs` folder. Just modify the path in configure files, then copy them to `/etc/systemd/system` folder.
+## Autostart
+To configure automatic authentication on systemd-based Linux distro, take a look at `docs` folder. Just modify the path in configuration files, then copy them to `/etc/systemd/system` folder.
 
-Note that the program should have access to the configure file. For `goauthing.service`, since it is run as `nobody`, `/etc/goauthing.json` can not be read by it, hence you can use the following command to enable access.
+Note that the program should have access to the configuration file.
+For `goauthing.service`, since it is run as `nobody`, `/etc/goauthing.json` can not be read by it, hence you can use the following command to enable access:
 
 ```
 setfacl -m u:nobody:r /etc/goauthing.json
 ```
 
-Or, to be more secure, you can choose `goauthing@.service` and store the config in home directory. 
+Or, to be more secure, you can choose `goauthing@.service` and store the configuration file in the home directory. 
+
+For OpenWRT users, there are two options available: `goauthing` loading the configuration file, and `goauthing@` interacting with the UCI. The init script should go to the `/etc/init.d/` folder. With the latter, use the following procedure to set up:
+
+```
+touch /etc/config/goauthing
+uci set goauthing.config.username='<YOUR-TUNET-ACCOUNT-NAME>'
+uci set goauthing.config.password='<YOUR-TUNET-PASSWORD>'
+uci commit goauthing
+/etc/init.d/goauthing enable
+/etc/init.d/goauthing start
+```
 
 It is suggested that one configures and runs it manually first with `debug` flag turned on, which ensures the correctness of one's config, then start it as system service. For `daemonize` flag, it forces the program to only log errors, hence debugging should be done earlier and manually. `daemonize` is automatically turned on for system service (ref to associated systemd unit files).
 

--- a/docs/goauthing
+++ b/docs/goauthing
@@ -1,0 +1,28 @@
+#!/bin/sh /etc/rc.common
+# Authenticating utility for auth.tsinghua.edu.cn
+# This init script is used explicitly with OpenWRT
+
+USE_PROCD=1
+START=98
+PROG="/usr/bin/goauthing"  # cp script to this path first
+CONF="/etc/goauthing.json"
+
+start_pre() {
+	"$PROG" -c "$CONF" -D deauth
+	"$PROG" -c "$CONF" -D auth
+	"$PROG" -c "$CONF" -D login
+}
+
+start_service() {
+	start_pre
+	procd_open_instance
+	procd_set_param command "$PROG"
+	procd_append_param command -c "$CONF" -D online
+	procd_set_param stderr 1
+	procd_set_param respawn
+	procd_close_instance
+}
+
+stop_service() {
+	"$PROG" -c "$CONF" -D logout
+}

--- a/docs/goauthing@
+++ b/docs/goauthing@
@@ -1,0 +1,45 @@
+#!/bin/sh /etc/rc.common
+# Authenticating utility for auth.tsinghua.edu.cn
+# This init script is used explicitly with OpenWRT
+
+USE_PROCD=1
+START=98
+PROG="/usr/bin/goauthing"
+SERV=goauthing  # UCI config at /etc/config/goauthing
+
+start_instance() {
+  local username password
+  config_get username config username
+  config_get password config password
+  local args="-u $username -p $password"
+
+  "$PROG" $args deauth
+  "$PROG" $args auth
+  "$PROG" $args login
+
+  procd_open_instance
+  procd_set_param command "$PROG"
+  procd_append_param command $args online
+  procd_set_param stderr 1
+  procd_set_param respawn
+  procd_close_instance
+}
+
+logout() {
+  local username password
+  config_get username config username
+  config_get password config password
+  local args="-u $username -p $password"
+
+  "$PROG" $args logout
+}
+
+start_service() {
+  config_load "$SERV"
+  config_foreach start_instance "$SERV"
+}
+
+stop_service() {
+  config_load "$SERV"
+  config_foreach logout "$SERV"
+}


### PR DESCRIPTION
#23

我按照原本 doc 内 service 的样式，写了两个用于 OpenWRT 的 procd init script：
- `goauthing` 读取 `CONF` 文件，用的是 `auth-thu -c`；
- `goauthing@` 和系统的 UCI 交互，读取 `/etc/config/goauthing` 中配置好的 TUNET 帐号密码。

`-D` 在 `goauthing@` 的情况下无法使用（`ERROR auth-thu main.go:362 Auth error: cannot find config file (it is necessary in daemon mode)`），所以我在 procd 中仅让它记录 Error，达到类似的 less log 功能。

另外，我斗胆修改了 README，加入了简单的 usage。前辈如果觉得不好，可以 modify 我的 commit。