### PR TITLE
Bump go version to 1.17 in `go.mod`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,19 @@
 module github.com/z4yx/GoAuthing
 
-go 1.12
+go 1.17
 
 require (
 	github.com/howeyc/gopass v0.0.0-20190910152052-7cb4b85ec19c
 	github.com/juju/loggo v0.0.0-20210728185423-eebad3a902c4
 	github.com/smartystreets/goconvey v1.6.4
-	golang.org/x/crypto v0.17.0 // indirect
 	gopkg.in/urfave/cli.v1 v1.20.0
+)
+
+require (
+	github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 // indirect
+	github.com/jtolds/gls v4.20.0+incompatible // indirect
+	github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d // indirect
+	golang.org/x/crypto v0.17.0 // indirect
+	golang.org/x/sys v0.15.0 // indirect
+	golang.org/x/term v0.15.0 // indirect
 )


### PR DESCRIPTION
This commit fix build in vendor mode.

Without this commit, `go mod vendor` then `go build -mod=vendor cli/main.go` would fail since go build modules using 1.16 as default version and `x/sys/unix` needs go 1.17.