### PR TITLE
Add Dockerfile and CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -42,3 +42,22 @@ jobs:
         CGO_ENABLED=0 GOARCH=riscv64 GOOS=linux go build -ldflags="-s -w" -o auth-thu.linux.riscv64 ./cli/main.go
         CGO_ENABLED=0 GOARCH=loong64 GOOS=linux go build -ldflags="-s -w" -o auth-thu.linux.loong64 ./cli/main.go
 
+  build-image:
+    name: Build Docker Image
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v4
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build the Docker image
+      uses: docker/build-push-action@v5
+      with:
+        push: false
+        context: .

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: '1.20'
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Get dependencies
       run: go get -v -t -d ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,3 +55,41 @@ jobs:
         tag_name="${GITHUB_REF##*/}"
         hub release edit $(find . -type f -executable -name "auth-thu.*" -printf "-a %p ") -m "" "$tag_name" 
 
+  build-image:
+    name: Build Image
+    runs-on: ubuntu-latest
+    needs: build
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+
+    steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v4
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to the Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    
+    - name: Extract metadata
+      id: metadata
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+    - name: Build and push the Docker image
+      uses: docker/build-push-action@v5
+      with:
+        push: true
+        context: .
+        tags: ${{ steps.metadata.outputs.tags }}
+        labels: ${{ steps.metadata.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: '1.20'
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Get dependencies
       run: go get -v -t -d ./...
@@ -39,21 +39,11 @@ jobs:
         CGO_ENABLED=0 GOARCH=loong64 GOOS=linux go build -ldflags="-s -w" -o auth-thu.linux.loong64 ./cli/main.go
 
     - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: ${{ github.ref }}
-        draft: false
-        prerelease: false 
-    - name: Upload Artifacts
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         tag_name="${GITHUB_REF##*/}"
-        hub release edit $(find . -type f -executable -name "auth-thu.*" -printf "-a %p ") -m "" "$tag_name" 
+        gh release create "$tag_name" -t "$tag_name" auth-thu.*
 
   build-image:
     name: Build Image

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:alpine AS builder
+
+WORKDIR /app
+COPY . .
+
+RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /app/auth-thu /app/cli/main.go
+
+FROM scratch
+
+COPY --from=builder /app/auth-thu /auth-thu
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+ENTRYPOINT [ "/auth-thu" ]

--- a/README.md
+++ b/README.md
@@ -126,6 +126,21 @@ uci commit goauthing
 /etc/init.d/goauthing start
 ```
 
+### Docker
+
+For Docker users, you can run the container with a restart policy. An example docker compose is like this:
+
+```yaml
+services:
+  goauthing:
+    image: ghcr.io/z4yx/goauthing:latest
+    container_name: goauthing
+    restart: always
+    volumes:
+      - /path/to/your/config:/.auth-thu
+   command: auth -k
+```
+
 ## Build
 
 Requires Go 1.11 or above


### PR DESCRIPTION
TLDR: Add a Dockerfile and adjust CI to build the image.

Changes:
- Add a Dockerfile to build an image based on `scratch`. This image can be used to run the app on a server without configuring `systemd` or other init systems (e.g., some commercial NAS devices may not support `systemd`).
- Add two GitHub Action jobs to build and push this image to GitHub Container Registry.
- Update several actions to the latest version to emit GitHub Action's warnings.
- Use the `gh` cli tool instead of the archived `actions/create-release` and `hub`, which was removed on 2023-10-02 (See [[All OS] hub utility will be removed on October 2](https://github.com/actions/runner-images/issues/8362))