### PR TITLE
Add keepAlive to auth's IsOnline branch

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -306,6 +306,9 @@ func authUtil(c *cli.Context, logout bool) error {
 		}
 		if online && !logout {
 			logger.Infof("Currently online!")
+			if settings.KeepOn {
+				return keepAliveLoop(c, true)
+			}
 			return nil
 		} else if !online && logout {
 			logger.Infof("Currently offline!")


### PR DESCRIPTION
Currently, `auth` exits if the IP is online and ignores the `--keep-online` parameter. This commit adds the `keepAliveLoop` to `auth`'s IsOnline branch to keep the IP online immediately.