### PR TITLE
fix: procd script cannot auto re-auth （procd脚本不能在掉线之后自动重新登录）

### DIFF
--- a/docs/init.d/goauthing
+++ b/docs/init.d/goauthing
@@ -7,17 +7,20 @@ START=98
 PROG="/usr/bin/goauthing"  # cp script to this path first
 CONF="/etc/goauthing.json"
 
-start_pre() {
-	"$PROG" -c "$CONF" -D deauth
-	"$PROG" -c "$CONF" -D auth
-	"$PROG" -c "$CONF" -D login
+generate_command() {
+CMD="\
+\"$PROG\" -c \"$CONF\" -D deauth; \
+\"$PROG\" -c \"$CONF\" -D auth; \
+\"$PROG\" -c \"$CONF\" -D login; \
+\"$PROG\" -c \"$CONF\" -D online; \
+"
 }
 
 start_service() {
-	start_pre
+	generate_command
 	procd_open_instance
-	procd_set_param command "$PROG"
-	procd_append_param command -c "$CONF" -D online
+	procd_set_param command sh
+	procd_append_param command -c "$CMD"
 	procd_set_param stderr 1
 	procd_set_param respawn
 	procd_close_instance

--- a/docs/init.d/goauthing@
+++ b/docs/init.d/goauthing@
@@ -7,19 +7,26 @@ START=98
 PROG="/usr/bin/goauthing"
 SERV=goauthing  # UCI config at /etc/config/goauthing
 
+generate_command() {
+CMD="\
+\"$PROG\" $1 deauth; \
+\"$PROG\" $1 auth; \
+\"$PROG\" $1 login; \
+\"$PROG\" $1 online; \
+"
+}
+
 start_instance() {
   local username password
   config_get username config username
   config_get password config password
   local args="-u $username -p $password"
 
-  "$PROG" $args deauth
-  "$PROG" $args auth
-  "$PROG" $args login
+  generate_command "$args"
 
   procd_open_instance
-  procd_set_param command "$PROG"
-  procd_append_param command $args online
+  procd_set_param command sh
+  procd_append_param command -c "$CMD"
   procd_set_param stderr 1
   procd_set_param respawn
   procd_close_instance


### PR DESCRIPTION
修复了procd脚本：`docs/init.d/goauthing`的问题。

之前的版本里，"deauth-auth-login"这个过程是通过`start_pre()`函数实现的：
https://github.com/z4yx/GoAuthing/blob/e42c2fd7f02b157538940795597d82a8b8802ca8/docs/init.d/goauthing#L10-L14

然而，原来的版本却只把`start_pre()`写成了`start_service()`中一次性调用的东西，而不是`procd_set_param command`调用的内容，而只有后者才是procd的`respwan`功能在进程退出时会去尝试重启的东西。
https://github.com/z4yx/GoAuthing/blob/e42c2fd7f02b157538940795597d82a8b8802ca8/docs/init.d/goauthing#L16-L24


以下内容的测试环境为OpenWrt 23.05.2：
之前的的情况是：
1. 由于某种原因掉线了
2. online进程退出
3. procd检测到，尝试respwan `command`参数中所设置的命令
4. procd拉起`auth-thu online`进程
5. 由于并没有执行过`auth-thu auth`命令恢复上线，所以网络还是处于不在线的状态。当然很快，online进程就又退出
6. 回到第2步。

本PR尝试修复这个问题，通过把"deauth-auth-login-online"四步作为一个整体，以shell的方式传递给procd。这样如果online进程退出，procd在respwan时，就会再次尝试完整的"deauth-auth-login-online"四步过程，而不是反复地尝试online。