### PR TITLE
Workaround the delay between `auth` command return success and `online` command can access Internet, by adding `sleep 3`

### DIFF
--- a/docs/init.d/goauthing
+++ b/docs/init.d/goauthing
@@ -11,6 +11,7 @@ start_pre() {
 	"$PROG" -c "$CONF" -D deauth
 	"$PROG" -c "$CONF" -D auth
 	"$PROG" -c "$CONF" -D login
+	sleep 3
 }
 
 start_service() {

--- a/docs/init.d/goauthing@
+++ b/docs/init.d/goauthing@
@@ -16,6 +16,7 @@ start_instance() {
   "$PROG" $args deauth
   "$PROG" $args auth
   "$PROG" $args login
+  sleep 3
 
   procd_open_instance
   procd_set_param command "$PROG"

--- a/docs/systemd/system/goauthing.service
+++ b/docs/systemd/system/goauthing.service
@@ -6,6 +6,7 @@ StartLimitIntervalSec=0
 ExecStartPre=-/usr/local/bin/auth-thu -c /etc/goauthing.json -D deauth
 ExecStartPre=-/usr/local/bin/auth-thu -c /etc/goauthing.json -D auth
 ExecStartPre=-/usr/local/bin/auth-thu -c /etc/goauthing.json -D login
+ExecStartPre=-sleep 3
 ExecStart=/usr/local/bin/auth-thu -c /etc/goauthing.json -D online
 User=nobody
 Restart=always

--- a/docs/systemd/system/goauthing6.service
+++ b/docs/systemd/system/goauthing6.service
@@ -5,6 +5,7 @@ StartLimitIntervalSec=0
 [Service]
 ExecStartPre=-/usr/local/bin/auth-thu -c /etc/goauthing.json -D deauth -6
 ExecStartPre=-/usr/local/bin/auth-thu -c /etc/goauthing.json -D auth -6
+ExecStartPre=-sleep 3
 ExecStart=/usr/local/bin/auth-thu -c /etc/goauthing.json -D online -6
 User=nobody
 Restart=always

--- a/docs/systemd/system/goauthing6@.service
+++ b/docs/systemd/system/goauthing6@.service
@@ -6,6 +6,7 @@ StartLimitIntervalSec=0
 # default config is in ~/.auth-thu
 ExecStartPre=-/usr/local/bin/auth-thu -D deauth -6
 ExecStartPre=-/usr/local/bin/auth-thu -D auth -6
+ExecStartPre=-sleep 3
 ExecStart=/usr/local/bin/auth-thu -D online -6
 User=%i
 Restart=always

--- a/docs/systemd/system/goauthing@.service
+++ b/docs/systemd/system/goauthing@.service
@@ -7,6 +7,7 @@ StartLimitIntervalSec=0
 ExecStartPre=-/usr/local/bin/auth-thu -D deauth
 ExecStartPre=-/usr/local/bin/auth-thu -D auth
 ExecStartPre=-/usr/local/bin/auth-thu -D login
+ExecStartPre=-sleep 3
 ExecStart=/usr/local/bin/auth-thu -D online
 User=%i
 Restart=always

--- a/docs/systemd/user/goauthing.service
+++ b/docs/systemd/user/goauthing.service
@@ -6,6 +6,7 @@ StartLimitIntervalSec = 0
 ExecStartPre = -/usr/local/bin/auth-thu -D deauth
 ExecStartPre = -/usr/local/bin/auth-thu -D auth
 ExecStartPre = -/usr/local/bin/auth-thu -D login
+ExecStartPre = -sleep 3
 ExecStart    = /usr/local/bin/auth-thu -D online
 Restart      = always
 RestartSec   = 5

--- a/docs/systemd/user/goauthing6.service
+++ b/docs/systemd/user/goauthing6.service
@@ -5,6 +5,7 @@ StartLimitIntervalSec = 0
 [Service]
 ExecStartPre = -/usr/local/bin/auth-thu -D deauth -6
 ExecStartPre = -/usr/local/bin/auth-thu -D auth -6
+ExecStartPre = -sleep 3
 ExecStart    = /usr/local/bin/auth-thu -D online -6
 Restart      = always
 RestartSec   = 5


### PR DESCRIPTION
最近观察到了一个现象（似乎以前并无这种现象）：
使用goauthing认证，`auth-thu auth`成功返回0后，立刻发起网络请求(如auth-thu online)，还是会返回自签名证书和Authentication is required。
也就是说，并不是auth4返回认证成功后就立刻能上外网，一定要等个几秒（目前测试3秒是足够的）才能成功访问外网。
测试网络环境：东配楼有线校园网 IPV4 166.111.80.0/22内。似乎IPV6无此现象。此外也有自强楼的同学反映也存在着同样的情况。

引起的问题主要是，goauthing的systemd配置实现是deauth、auth之后立刻online保活。于是由于上述延迟的存在，紧跟着auth/login命令后马上执行的online是几乎一定会挂掉(exit 1)的。于是unit failed，systemd把它自动重启，又deauth、auth、立刻online导致挂掉......导致始终无法稳定连上网。

我目前想到的比较容易的一种解决方法就是在auth/login和online之间加个sleep 3。不够优雅，但亲测有效，所以就当抛砖引玉了。