### PR TITLE
Remove legacy `auth-thu login` command in systemd service files.

### DIFF
--- a/docs/systemd/system/goauthing.service
+++ b/docs/systemd/system/goauthing.service
@@ -5,7 +5,6 @@ StartLimitIntervalSec=0
 [Service]
 ExecStartPre=-/usr/local/bin/auth-thu -c /etc/goauthing.json -D deauth
 ExecStartPre=-/usr/local/bin/auth-thu -c /etc/goauthing.json -D auth
-ExecStartPre=-/usr/local/bin/auth-thu -c /etc/goauthing.json -D login
 ExecStart=/usr/local/bin/auth-thu -c /etc/goauthing.json -D online
 User=nobody
 Restart=always

--- a/docs/systemd/system/goauthing.service
+++ b/docs/systemd/system/goauthing.service
@@ -5,7 +5,7 @@ StartLimitIntervalSec=0
 [Service]
 ExecStartPre=-/usr/local/bin/auth-thu -c /etc/goauthing.json -D deauth
 ExecStartPre=-/usr/local/bin/auth-thu -c /etc/goauthing.json -D auth
-ExecStart=/usr/local/bin/auth-thu -c /etc/goauthing.json -D online
+ExecStart=/usr/local/bin/auth-thu -c /etc/goauthing.json online
 User=nobody
 Restart=always
 RestartSec=5

--- a/docs/systemd/system/goauthing6.service
+++ b/docs/systemd/system/goauthing6.service
@@ -5,7 +5,7 @@ StartLimitIntervalSec=0
 [Service]
 ExecStartPre=-/usr/local/bin/auth-thu -c /etc/goauthing.json -D deauth -6
 ExecStartPre=-/usr/local/bin/auth-thu -c /etc/goauthing.json -D auth -6
-ExecStart=/usr/local/bin/auth-thu -c /etc/goauthing.json -D online -6
+ExecStart=/usr/local/bin/auth-thu -c /etc/goauthing.json online -6
 User=nobody
 Restart=always
 RestartSec=5

--- a/docs/systemd/system/goauthing6@.service
+++ b/docs/systemd/system/goauthing6@.service
@@ -6,7 +6,7 @@ StartLimitIntervalSec=0
 # default config is in ~/.auth-thu
 ExecStartPre=-/usr/local/bin/auth-thu -D deauth -6
 ExecStartPre=-/usr/local/bin/auth-thu -D auth -6
-ExecStart=/usr/local/bin/auth-thu -D online -6
+ExecStart=/usr/local/bin/auth-thu online -6
 User=%i
 Restart=always
 RestartSec=5

--- a/docs/systemd/system/goauthing@.service
+++ b/docs/systemd/system/goauthing@.service
@@ -6,7 +6,7 @@ StartLimitIntervalSec=0
 # default config is in ~/.auth-thu
 ExecStartPre=-/usr/local/bin/auth-thu -D deauth
 ExecStartPre=-/usr/local/bin/auth-thu -D auth
-ExecStart=/usr/local/bin/auth-thu -D online
+ExecStart=/usr/local/bin/auth-thu online
 User=%i
 Restart=always
 RestartSec=5

--- a/docs/systemd/system/goauthing@.service
+++ b/docs/systemd/system/goauthing@.service
@@ -6,7 +6,6 @@ StartLimitIntervalSec=0
 # default config is in ~/.auth-thu
 ExecStartPre=-/usr/local/bin/auth-thu -D deauth
 ExecStartPre=-/usr/local/bin/auth-thu -D auth
-ExecStartPre=-/usr/local/bin/auth-thu -D login
 ExecStart=/usr/local/bin/auth-thu -D online
 User=%i
 Restart=always

--- a/docs/systemd/user/goauthing.service
+++ b/docs/systemd/user/goauthing.service
@@ -5,7 +5,7 @@ StartLimitIntervalSec = 0
 [Service]
 ExecStartPre = -/usr/local/bin/auth-thu -D deauth
 ExecStartPre = -/usr/local/bin/auth-thu -D auth
-ExecStart    = /usr/local/bin/auth-thu -D online
+ExecStart    = /usr/local/bin/auth-thu online
 Restart      = always
 RestartSec   = 5
 

--- a/docs/systemd/user/goauthing.service
+++ b/docs/systemd/user/goauthing.service
@@ -5,7 +5,6 @@ StartLimitIntervalSec = 0
 [Service]
 ExecStartPre = -/usr/local/bin/auth-thu -D deauth
 ExecStartPre = -/usr/local/bin/auth-thu -D auth
-ExecStartPre = -/usr/local/bin/auth-thu -D login
 ExecStart    = /usr/local/bin/auth-thu -D online
 Restart      = always
 RestartSec   = 5

--- a/docs/systemd/user/goauthing6.service
+++ b/docs/systemd/user/goauthing6.service
@@ -5,7 +5,7 @@ StartLimitIntervalSec = 0
 [Service]
 ExecStartPre = -/usr/local/bin/auth-thu -D deauth -6
 ExecStartPre = -/usr/local/bin/auth-thu -D auth -6
-ExecStart    = /usr/local/bin/auth-thu -D online -6
+ExecStart    = /usr/local/bin/auth-thu online -6
 Restart      = always
 RestartSec   = 5
 


### PR DESCRIPTION
legacy net.tsinghua.edu.cn support and login/logout commands had already been dropped in 506a920, so change systemd files in accordance to it.