### PR TITLE
keepAlive功能，增加选项控制重试次数和重试间隔

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -303,7 +303,7 @@ func authUtil(c *cli.Context, logout bool) error {
 		if online && !logout {
 			logger.Infof("Currently online!")
 			if settings.KeepOn {
-				return keepAliveLoop(c, true)
+				return keepAliveLoop(c, settings.Campus)
 			}
 			return nil
 		} else if !online && logout {
@@ -345,7 +345,7 @@ func authUtil(c *cli.Context, logout bool) error {
 			if len(settings.Ip) != 0 {
 				logger.Errorf("Cannot keep another IP online\n")
 			} else {
-				return keepAliveLoop(c, true)
+				return keepAliveLoop(c, settings.Campus)
 			}
 		}
 	} else {

--- a/cli/main.go
+++ b/cli/main.go
@@ -398,7 +398,7 @@ func cmdKeepalive(c *cli.Context) {
 		logger.Errorf("Parse setting error: %s\n", err)
 		os.Exit(1)
 	}
-	err = keepAliveLoop(c, c.Bool("auth"))
+	err = keepAliveLoop(c, c.Bool("campus-only"))
 	if err != nil {
 		logger.Errorf("Keepalive error: %s\n", err)
 		os.Exit(1)
@@ -463,7 +463,7 @@ func main() {
 				Name:  "online",
 				Usage: "Keep your computer online",
 				Flags: []cli.Flag{
-					&cli.BoolFlag{Name: "auth, a", Usage: "keep the Auth online only"},
+					&cli.BoolFlag{Name: "campus-only, C, auth, a", Usage: "keep alive by requesting in-campus site instead of Internet site"},
 					&cli.BoolFlag{Name: "ipv6, 6", Usage: "keep only ipv6 connection online"},
 					&cli.IntFlag{Name: "retry, r", Usage: "the repeat times of failed keepAlive requests before keepAliveLoop exits with error", Value: 2},
 				},


### PR DESCRIPTION
此前的讨论见#40。

根据 https://github.com/z4yx/GoAuthing/pull/40#issuecomment-2320764960 的建议，本PR实现了keepAliveLoop并不会在请求失败就立即退出，而是重复尝试可定义的次数，只有连续失败若干次后才会退出。同时，两次重试之间的时间间隔现在也可定义了（之前是写死的3s）。

具体实现：
1. commit 7ef821d，修复了d0b9776中的不完善之处：`auth-thu auth --keep-online`的keepAlive，应该根据`--campus-only`的有无决定keepAlive的校内校外，而不应固定写死keepAlive校内。
2. commit 73227cb 是核心的commit，添加了两个配置项：
    - `onlineRetry`，决定keepAliveLoop在退出之前应当尝试的次数，默认值为2，即只有连续两次keepAlive请求报错，keepAliveLoop才会退出。
      - > 注意这轻微改变了online的行为，如果想要和原来一样的行为（一次请求失败就立即退出），则需要显式指定`onlineRetry`为1：`auth-thu online -r 1`。
    - `onlineInterval`，决定两次keepAlive请求之间的间隔，默认值为3s（和原来写死在代码里的值一致）
3. commit 7ef821d 是小修改，把`auth-thu online --auth`的`--auth`增加一个alias名为`--campus-only`。这是因为`--auth`原本在旧版的系统下表示只auth不login，但目前login功能已被完全移除，故该名称也失去了其含义；改为`--campus-only`，是和`auth-thu auth`中的同义选项保持一致的选择。

Close #40.
