### PR TITLE
Fix OpenWRT support

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ For OpenWRT users, there are two options available: `goauthing` loading the conf
 
 ```shell
 touch /etc/config/goauthing
+uci set goauthing.config=goauthing
 uci set goauthing.config.username='<YOUR-TUNET-ACCOUNT-NAME>'
 uci set goauthing.config.password='<YOUR-TUNET-PASSWORD>'
 uci commit goauthing

--- a/docs/init.d/goauthing@
+++ b/docs/init.d/goauthing@
@@ -43,10 +43,10 @@ logout() {
 
 start_service() {
   config_load "$SERV"
-  config_foreach start_instance "$SERV"
+  start_instance
 }
 
 stop_service() {
   config_load "$SERV"
-  config_foreach logout "$SERV"
+  logout
 }


### PR DESCRIPTION
Two changes were made:

1. According to the documentation in `README.md`, running `uci set goauthing.config.username='<YOUR-TUNET-ACCOUNT-NAME>'` immediately after `touch /etc/config/goauthing` results in the error `uci: Invalid argument`. This can be resolved by running `uci set goauthing.config=goauthing` beforehand.

2. In the `docs/init.d/goauthing@` file, the use of `config_foreach` appears to be unnecessary.

Issue resolved: https://github.com/z4yx/GoAuthing/issues/30